### PR TITLE
Ignore times in date comparisons

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -2,20 +2,21 @@ extension DateTimeExtensions on DateTime {
   /// Returns `true` if this date is earlier than the given [date].
   ///
   /// This considers only the date, not the time.
-  bool isEarlierDateThan(DateTime date) =>
-      year < date.year || month < date.month || day < date.day;
+  bool isEarlierDateThan(DateTime date) => zeroTime.isBefore(date.zeroTime);
 
   /// Returns `true` if this date is later than the given [date].
   ///
   /// This considers only the date, not the time.
-  bool isLaterDateThan(DateTime date) =>
-      year > date.year || month > date.month || day > date.day;
+  bool isLaterDateThan(DateTime date) => zeroTime.isAfter(date.zeroTime);
 
   /// Returns `true` if this date is the same as the given [date].
   ///
   /// This considers only the date, not the time.
-  bool isSameDateAs(DateTime date) =>
-      year == date.year && month == date.month && day == date.day;
+  bool isSameDateAs(DateTime date) => zeroTime == date.zeroTime;
+
+  /// Returns a new [DateTime] with the time set to `00:00:00`.
+  DateTime get zeroTime => DateTime(year, month, day);
+
 
   /// Calculates the number of months between this date and the given [date].
   int getMonthsApartFrom(DateTime date) {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -23,18 +23,23 @@ extension DateTimeExtensions on DateTime {
       zeroTime.difference(date.zeroTime).inDays.abs();
 
   /// Calculates the number of months between this date and the given [date].
-  int getMonthsApartFrom(DateTime date) {
+  int monthsApartFrom(DateTime date) {
+    final dayOfMonthAdjustment = date.day >= day ? 0 : -1;
+
     if (date.year == year) {
-      return (date.month - month).abs();
+      final months = (date.month - month).abs();
+      return months + dayOfMonthAdjustment;
     }
 
     final yearDiff = (date.year - year).abs();
 
     if (yearDiff == 1) {
-      return (12 - month) + date.month;
+      final months = (12 - month) + date.month;
+      return months + dayOfMonthAdjustment;
     }
 
     final yearDiffInMonths = (yearDiff - 1) * 12;
-    return (12 - month) + date.month + yearDiffInMonths;
+    final months = (12 - month) + date.month + yearDiffInMonths;
+    return months + dayOfMonthAdjustment;
   }
 }

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -17,6 +17,10 @@ extension DateTimeExtensions on DateTime {
   /// Returns a new [DateTime] with the time set to `00:00:00`.
   DateTime get zeroTime => DateTime(year, month, day);
 
+  /// Calculates the number of days between this date and the given [date],
+  /// ignoring the time.
+  int daysApartFrom(DateTime date) =>
+      zeroTime.difference(date.zeroTime).inDays.abs();
 
   /// Calculates the number of months between this date and the given [date].
   int getMonthsApartFrom(DateTime date) {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -2,25 +2,22 @@ extension DateTimeExtensions on DateTime {
   /// Returns `true` if this date is earlier than the given [date].
   ///
   /// This considers only the date, not the time.
-  bool isEarlierDateThan(DateTime date) => zeroTime.isBefore(date.zeroTime);
+  bool isEarlierDateThan(DateTime date) => _dayOnly().isBefore(date._dayOnly());
 
   /// Returns `true` if this date is later than the given [date].
   ///
   /// This considers only the date, not the time.
-  bool isLaterDateThan(DateTime date) => zeroTime.isAfter(date.zeroTime);
+  bool isLaterDateThan(DateTime date) => _dayOnly().isAfter(date._dayOnly());
 
   /// Returns `true` if this date is the same as the given [date].
   ///
   /// This considers only the date, not the time.
-  bool isSameDateAs(DateTime date) => zeroTime == date.zeroTime;
-
-  /// Returns a new [DateTime] with the time set to `00:00:00`.
-  DateTime get zeroTime => DateTime(year, month, day);
+  bool isSameDateAs(DateTime date) => _dayOnly() == date._dayOnly();
 
   /// Calculates the number of days between this date and the given [date],
   /// ignoring the time.
   int daysApartFrom(DateTime date) =>
-      zeroTime.difference(date.zeroTime).inDays.abs();
+      _dayOnly().difference(date._dayOnly()).inDays.abs();
 
   /// Calculates the number of months between this date and the given [date].
   int monthsApartFrom(DateTime date) {
@@ -42,4 +39,6 @@ extension DateTimeExtensions on DateTime {
     final months = (12 - month) + date.month + yearDiffInMonths;
     return months + dayOfMonthAdjustment;
   }
+
+  DateTime _dayOnly() => DateTime(year, month, day);
 }

--- a/lib/src/schedules.dart
+++ b/lib/src/schedules.dart
@@ -132,7 +132,7 @@ class Monthly extends Schedule {
       return false;
     }
 
-    final difference = startDate.getMonthsApartFrom(date);
+    final difference = startDate.monthsApartFrom(date);
     return difference % frequency == 0;
   }
 }

--- a/lib/src/schedules.dart
+++ b/lib/src/schedules.dart
@@ -67,7 +67,7 @@ class Daily extends Schedule {
       return false;
     }
 
-    final difference = startDate.difference(date).inDays;
+    final difference = startDate.daysApartFrom(date);
     return difference % frequency == 0;
   }
 }
@@ -99,7 +99,7 @@ class Weekly extends Schedule {
       return false;
     }
 
-    final difference = startDate.difference(date).inDays.abs();
+    final difference = startDate.daysApartFrom(date);
     final numWeeks = difference ~/ 7;
     return numWeeks % frequency == 0;
   }

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -84,14 +84,14 @@ void main() {
     group('#getMonthsApartFrom', () {
       test('is 0 for the same date', () {
         expect(
-          DateTime(2023, 01, 01).getMonthsApartFrom(DateTime(2023, 01, 01)),
+          DateTime(2023, 01, 01).monthsApartFrom(DateTime(2023, 01, 01)),
           equals(0),
         );
       });
 
       test('is 1 for one month apart', () {
         expect(
-          DateTime(2023, 01, 01).getMonthsApartFrom(DateTime(2023, 02, 01)),
+          DateTime(2023, 01, 01).monthsApartFrom(DateTime(2023, 02, 01)),
           equals(1),
         );
       });
@@ -100,23 +100,46 @@ void main() {
           'is correct count for months in different years, but less than 1 year apart',
           () {
         expect(
-          DateTime(2023, 11, 01).getMonthsApartFrom(DateTime(2024, 02, 01)),
+          DateTime(2023, 11, 01).monthsApartFrom(DateTime(2024, 02, 01)),
           equals(3),
         );
       });
 
       test('is correct count for months in the same year', () {
         expect(
-          DateTime(2023, 11, 01).getMonthsApartFrom(DateTime(2023, 02, 01)),
+          DateTime(2023, 11, 01).monthsApartFrom(DateTime(2023, 02, 01)),
           equals(9),
         );
       });
 
       test('is correct count for multiple years apart', () {
         expect(
-          DateTime(2023, 11, 01).getMonthsApartFrom(DateTime(2025, 02, 01)),
+          DateTime(2023, 11, 01).monthsApartFrom(DateTime(2025, 02, 01)),
           equals(15),
         );
+      });
+
+      group('day-of-month adjustment', () {
+        test('same year', () {
+          expect(
+            DateTime(2023, 01, 31).monthsApartFrom(DateTime(2023, 03, 15)),
+            equals(1),
+          );
+        });
+
+        test('different year and less than 12 months', () {
+          expect(
+            DateTime(2023, 10, 25).monthsApartFrom(DateTime(2024, 03, 15)),
+            equals(4),
+          );
+        });
+
+        test('different year and more than 12 months', () {
+          expect(
+            DateTime(2023, 10, 25).monthsApartFrom(DateTime(2025, 03, 15)),
+            equals(16),
+          );
+        });
       });
     });
   });

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -24,6 +24,15 @@ void main() {
           isFalse,
         );
       });
+
+      test('disregards times', () {
+        expect(
+          DateTime(2023, 01, 01, 12, 30, 45).isEarlierDateThan(
+            DateTime(2023, 01, 01, 12, 45, 00),
+          ),
+          isFalse,
+        );
+      });
     });
 
     group('#isLaterDateThan', () {
@@ -45,6 +54,15 @@ void main() {
         expect(
           DateTime(2023, 01, 02).isLaterDateThan(DateTime(2023, 01, 01)),
           isTrue,
+        );
+      });
+
+      test('disregards times', () {
+        expect(
+          DateTime(2023, 01, 01, 12, 30, 45).isLaterDateThan(
+            DateTime(2023, 01, 01, 12, 15, 00),
+          ),
+          isFalse,
         );
       });
     });

--- a/test/schedules_test.dart
+++ b/test/schedules_test.dart
@@ -6,8 +6,13 @@ void main() {
     group(Singular, () {
       group('#occursOn', () {
         test('is true on the correct date', () {
-          final schedule = Singular(date: DateTime(2023, 01, 01));
-          expect(schedule.occursOn(DateTime(2023, 01, 01)), isTrue);
+          final schedule = Singular(date: DateTime(2023, 01, 01, 12, 30, 45));
+          expect(schedule.occursOn(DateTime(2023, 01, 01, 12, 45, 30)), isTrue);
+        });
+
+        test('is true with differing times', () {
+          final schedule = Singular(date: DateTime(2023, 01, 01, 12, 30, 45));
+          expect(schedule.occursOn(DateTime(2023, 01, 01, 12, 45, 00)), isTrue);
         });
 
         test('is false for incorrect date', () {
@@ -21,23 +26,23 @@ void main() {
       group('#occursOn', () {
         test('is true on the start date', () {
           final schedule = Daily(
-            startDate: DateTime(2023, 01, 01),
+            startDate: DateTime(2023, 01, 01, 12, 30, 45),
             frequency: 1,
           );
 
-          expect(schedule.occursOn(DateTime(2023, 01, 01)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 01, 12, 45, 30)), isTrue);
         });
 
         test('is true on the pattern', () {
           final schedule = Daily(
-            startDate: DateTime(2023, 01, 01),
+            startDate: DateTime(2023, 01, 01, 8, 15, 45),
             frequency: 3,
           );
 
-          expect(schedule.occursOn(DateTime(2023, 01, 04)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 01, 07)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 01, 10)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 02, 03)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 04, 3, 19, 7)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 07, 8, 12, 45)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 10, 20, 19, 19)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 02, 03, 13, 13, 13)), isTrue);
         });
 
         test('is false before the start date', () {
@@ -75,26 +80,26 @@ void main() {
 
         test('is true after the start date on the correct weekday', () {
           final schedule = Weekly(
-            startDate: DateTime(2023, 01, 01),
+            startDate: DateTime(2023, 01, 01, 12, 30, 45),
             frequency: 1,
             weekdays: [DateTime.monday],
           );
 
-          expect(schedule.occursOn(DateTime(2023, 01, 02)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 02, 12, 45, 30)), isTrue);
         });
 
         test('is true on the correct weekdays', () {
           final schedule = Weekly(
-            startDate: DateTime(2023, 01, 01),
+            startDate: DateTime(2023, 01, 01, 12, 34, 56),
             frequency: 3,
             weekdays: [DateTime.monday, DateTime.friday],
           );
 
-          expect(schedule.occursOn(DateTime(2023, 01, 06)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 01, 23)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 01, 27)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 02, 13)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 06, 19)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 06, 07, 08, 09)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 23, 23, 23, 23)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 27, 19, 19, 19)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 02, 13, 13, 13, 13)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 06, 19, 19, 19, 19)), isTrue);
         });
 
         test('is false on incorrect weekdays', () {
@@ -146,25 +151,25 @@ void main() {
 
         test('is true on the start date if it is a selected date', () {
           final schedule = Monthly(
-            startDate: DateTime(2023, 01, 02),
+            startDate: DateTime(2023, 01, 02, 03, 04, 05),
             days: [2],
             frequency: 1,
           );
 
-          expect(schedule.occursOn(DateTime(2023, 01, 02)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 02, 05, 04, 03)), isTrue);
         });
 
         test('is true on a correct date', () {
           final schedule = Monthly(
-            startDate: DateTime(2023, 01, 01),
+            startDate: DateTime(2023, 01, 01, 02, 03, 04),
             days: [1, 15],
             frequency: 2,
           );
 
-          expect(schedule.occursOn(DateTime(2023, 01, 15)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 03, 01)), isTrue);
-          expect(schedule.occursOn(DateTime(2023, 03, 15)), isTrue);
-          expect(schedule.occursOn(DateTime(2024, 03, 15)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 15, 15, 15, 15)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 03, 01, 01, 01, 01)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 03, 15, 15, 15, 15)), isTrue);
+          expect(schedule.occursOn(DateTime(2024, 03, 15, 15, 15, 15)), isTrue);
         });
 
         test('is false on an incorrect date', () {
@@ -207,22 +212,22 @@ void main() {
       group('#occursOn', () {
         test('is true on the start date', () {
           final schedule = Yearly(
-            startDate: DateTime(2023, 01, 01),
+            startDate: DateTime(2023, 01, 01, 12, 30, 30),
             frequency: 1,
           );
 
-          expect(schedule.occursOn(DateTime(2023, 01, 01)), isTrue);
+          expect(schedule.occursOn(DateTime(2023, 01, 01, 13, 13, 13)), isTrue);
         });
 
         test('is true on a correct date', () {
           final schedule = Yearly(
-            startDate: DateTime(2023, 01, 01),
+            startDate: DateTime(2023, 01, 01, 12, 30, 30),
             frequency: 2,
           );
 
-          expect(schedule.occursOn(DateTime(2025, 01, 01)), isTrue);
-          expect(schedule.occursOn(DateTime(2027, 01, 01)), isTrue);
-          expect(schedule.occursOn(DateTime(2029, 01, 01)), isTrue);
+          expect(schedule.occursOn(DateTime(2025, 01, 01, 02, 03, 04)), isTrue);
+          expect(schedule.occursOn(DateTime(2027, 01, 01, 04, 05, 06)), isTrue);
+          expect(schedule.occursOn(DateTime(2029, 01, 01, 06, 07, 08)), isTrue);
         });
 
         test('is false on an incorrect date', () {


### PR DESCRIPTION
Updates many of the extension methods, and adds a new one, to fix bugs in the date comparisons that weren't properly ignoring the timestamps.

Also updates the tests to ensure that the timestamps do not affect the comparisons.

This resolves #4 